### PR TITLE
Change markdown parser from markdown to pulldown-cmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "handlebars"
 version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,17 +360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "markdown"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef3aab6a1d529b112695f72beec5ee80e729cb45af58663ec902c8fac764ecdd"
-dependencies = [
- "lazy_static",
- "pipeline",
- "regex",
-]
-
-[[package]]
 name = "mdbook"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,12 +386,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "mdbook-section-number"
-version = "0.1.0"
+name = "mdbook-chapter-number"
+version = "0.1.1"
 dependencies = [
- "markdown",
  "mdbook",
  "pretty_assertions",
+ "pulldown-cmark",
+ "pulldown-cmark-to-cmark",
  "serde_json",
  "structopt",
 ]
@@ -499,12 +498,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pipeline"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15b6607fa632996eb8a17c9041cb6071cb75ac057abd45dece578723ea8c7c0"
-
-[[package]]
 name = "pretty_assertions"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,8 +549,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
 dependencies = [
  "bitflags",
+ "getopts",
  "memchr",
  "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-to-cmark"
+version = "10.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0194e6e1966c23cc5fd988714f85b18d548d773e81965413555d96569931833d"
+dependencies = [
+ "pulldown-cmark",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ exclude = [".idea", ".gitignore", ".github"]
 mdbook = { version = "0.4.21", default-features = false }
 structopt = "0.3.26"
 serde_json = "1.0.85"
-markdown = "0.3.0"
+pulldown-cmark = "0.9.2"
+pulldown-cmark-to-cmark = "10.0.4"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/example/src/chapter_1_1.md
+++ b/example/src/chapter_1_1.md
@@ -1,1 +1,7 @@
 # Sub Chapter `hello, world`
+
+* This is a non-ordered list
+* second item
+
+1. This is an ordered list
+2. second item


### PR DESCRIPTION
[markdown](https://crates.io/crates/markdown) crate did not support ordered list rendering.
We now start to use [pulldown-cmark](https://crates.io/crates/pulldown-cmark), which is used in mdbook crate.