### PR TITLE
Release for v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.1.3](https://github.com/Mura-Mi/mdbook-chapter-number/compare/v0.1.2...v0.1.3) - 2022-10-14
+- Update Rust crate serde_json to 1.0.86 by @renovate in https://github.com/Mura-Mi/mdbook-chapter-number/pull/10
+
 ## [v0.1.2](https://github.com/Mura-Mi/mdbook-chapter-number/compare/v0.1.1...v0.1.2) - 2022-09-29
 - Introduce tagpr by @Mura-Mi in https://github.com/Mura-Mi/mdbook-chapter-number/pull/5
 - Change markdown parser from markdown to pulldown-cmark by @Mura-Mi in https://github.com/Mura-Mi/mdbook-chapter-number/pull/7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-chapter-number"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 license = "MIT"
 description = "A mdBook preprocessor that adds chapter numbers to the each page header"


### PR DESCRIPTION
This pull request is for the next release as v0.1.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.1.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Update Rust crate serde_json to 1.0.86 by @renovate in https://github.com/Mura-Mi/mdbook-chapter-number/pull/10


**Full Changelog**: https://github.com/Mura-Mi/mdbook-chapter-number/compare/v0.1.2...v0.1.3